### PR TITLE
#29 removed hardcoded type key from handlers and using default log

### DIFF
--- a/logagg/collect/collector.py
+++ b/logagg/collect/collector.py
@@ -67,7 +67,8 @@ class LogCollector(BaseScript):
                     host=HOST,
                     handler=L['handler'],
                     raw=line,
-                    timestamp=datetime.datetime.utcnow().isoformat()
+                    timestamp=datetime.datetime.utcnow().isoformat(),
+                    type=json.loads(line).get("type", "log")
                   )
 
             try:

--- a/logagg/collect/handlers.py
+++ b/logagg/collect/handlers.py
@@ -19,7 +19,6 @@ def nginx_access(line):
     log = convert_str2int(log)
 
     return dict(
-        type='log',
         timestamp=log.get('timestamp',' '),
         data=log
     )
@@ -36,7 +35,6 @@ def mongodb(line):
     mongodb_log = dict(zip(keys,values))
 
     return dict(
-        type='log',
         timestamp=values[0],
         data=mongodb_log
     )
@@ -85,13 +83,11 @@ def django(line):
         data['message'] = message
 
         return dict(
-                type='log',
                 timestamp=data['timestamp'],
                 data=data
             )
     else:
         return dict(
-            type='log',
             timestamp=datetime.datetime.isoformat(datetime.datetime.utcnow()),
             data=line
         )
@@ -139,14 +135,12 @@ def basescript(line):
 
     log = json.loads(line)
     is_metric = log.get('influx_metric', False)
-    _type = 'metric' if is_metric else 'log'
     if is_metric:
 	event = log.get('event', ' ')
 	event_dict = _parse_metric_event(event)
 	log['event'] = event_dict
 
     return dict(
-        type=_type,
         timestamp=log.get('timestamp', ' '),
         data=log
     )
@@ -184,14 +178,12 @@ def elasticsearch(line):
         data = convert_str2int(data)
 
         return dict(
-                type='log',
                 timestamp=values[0],
                 data=data
         )
 
     else:
         return dict(
-                type='log',
                 timestamp=datetime.datetime.isoformat(datetime.datetime.now()),
                 data=line
         )


### PR DESCRIPTION
Connected to #29 
**Enhancements:**
- Removed hardcoded **type** key in handler level
- Considering type key from `basescript`
- If any log doesn't contain `type`  key, we are considering default value as **log**