### PR TITLE
Bug fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,8 @@ deploy:
     skip_cleanup: true
     api-key:
       secure: Rxl45qbTHWIbOhst3PS60ETfW5wDByxp0xv4ZbtgRGe4SPvHtOLHRNGiajsQX37pgUFF9ALcCseY2cTk46jNEA1jOzFx4DDSKyH+Wu4H5F4M8JDBBlIsvsgezumLsYMqOL18caZA8J84N9UyuzgdPBDb0B0mMclRa9xRaxWncrUZgXwW9r3N2zU1LvGtd0Su4zLXXP6HC6mKHdOOaNSDONqaesx1njYTGr5fbWy7IXrjSg75wWCtHW1dKDPXmyyWZomwpmhURYfYXn/o9lRaXSDpLWx4xTsbJQdG9EiSPm5fLjfv9tZTxIF7jB0tTrOB63gGAgrLu0zC5Z5MJ1Y0+sbotI8eySI4w0GTffhi4WQjTTyO02vgPuSCm9JV5aW+YeNJtSncEgaVgsuUmZUiWdqMsvPG+bqOjh/i0eIkHr/v7cyf3HndFieZH9H3XdlEDtyr4SRExQSjG+be6mcGOJMWMrXervcW6kGP3pcX7EWgrFxnkz9lSgx/0meNMP4JDo8pZWg50b0xpni3zUcweTgCIeYUBd5aIKUvPaCqSHC1BAyZI5z3Cvdlq0tjCS726drQcV4OJNjrnmb301/K6MBbXhAsyhbkB1NpUZ0k0ZwmGxQ7iE4N1pod2BQbTPxjNUL1KNQJXFvjr9Clrw9Arqo6X9S9t//GP2DDl5Ke5KQ=
-    name: logagg-0.2.8
-    tag_name: 0.2.8
+    name: logagg-0.2.9
+    tag_name: 0.2.9
     on:
         branch: master
         repo: deep-compute/logagg

--- a/logagg/collector.py
+++ b/logagg/collector.py
@@ -72,7 +72,10 @@ class LogCollector(object):
     def validate_log_format(self, log):
         for key in log:
             assert (key in self.LOG_STRUCTURE)
-            assert isinstance(log[key], self.LOG_STRUCTURE[key])
+            try:
+                assert isinstance(log[key], self.LOG_STRUCTURE[key])
+            except AssertionError as e:
+                self.log.exception('formatted_log_structure_rejected' , log=log)
 
     @keeprunning(LOG_FILE_POLL_INTERVAL, on_error=util.log_exception)
     def collect_log_lines(self, log_file):
@@ -84,7 +87,6 @@ class LogCollector(object):
         for line_info in freader:
             line = line_info['line'][:-1] # remove new line char at the end
             log = dict(
-                    id=None,
                     file=fpath,
                     host=self.HOST,
                     formatter=L['formatter'],
@@ -107,6 +109,7 @@ class LogCollector(object):
                 log.update(_log)
                 if 'id' not in log:
                     log['id'] = uuid.uuid1().hex
+                #import pdb; pdb.set_trace()
                 log = self._remove_redundancy(log)
                 self.validate_log_format(log)
             except (SystemExit, KeyboardInterrupt) as e: raise

--- a/logagg/collector.py
+++ b/logagg/collector.py
@@ -109,7 +109,6 @@ class LogCollector(object):
                 log.update(_log)
                 if 'id' not in log:
                     log['id'] = uuid.uuid1().hex
-                #import pdb; pdb.set_trace()
                 log = self._remove_redundancy(log)
                 self.validate_log_format(log)
             except (SystemExit, KeyboardInterrupt) as e: raise

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
         "pymongo==3.6.0",
         "nsq-py==0.1.10",
         "influxdb==4.1.1",
-        "deeputil==0.1.2",
+        "deeputil==0.2.5",
         "ujson==1.35",
     ],
     package_dir={'logagg': 'logagg'},

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages
 
 setup(
     name="logagg",
-    version="0.2.8",
+    version="0.2.9",
     description="logs aggregation framework",
     keywords="logagg",
     author="Deep Compute, LLC",


### PR DESCRIPTION
There was a bug in the code due to which collector was sending msgs of more than 5mb limit to nsq. Which resulted in : 
```
{"exception": "Traceback (most recent call last):\n  File \"/usr/local/lib/python2.7/dist-packages/deeputil/keep_running.py\", line 150, in _fn\n    fn(*args, **kwargs)\n  File \"/usr/local/lib/python2.7/dist-packages/logagg/nsqsender.py\", line 85, in _send_messages\n    self.session.post(url, data=data, timeout=5) # TODO What if session expires?\n  File \"/usr/local/lib/python2.7/dist-packages/requests/sessions.py\", line 555, in post\n    return self.request('POST', url, data=data, json=json, **kwargs)\n  File \"/usr/local/lib/python2.7/dist-packages/requests/sessions.py\", line 508, in request\n    resp = self.send(prep, **send_kwargs)\n  File \"/usr/local/lib/python2.7/dist-packages/requests/sessions.py\", line 618, in send\n    r = adapter.send(request, **kwargs)\n  File \"/usr/local/lib/python2.7/dist-packages/requests/adapters.py\", line 490, in send\n    raise ConnectionError(err, request=request)\nConnectionError: ('Connection aborted.', error(32, 'Broken pipe'))", "level": "error", "timestamp": "2018-03-21T10:37:11.528014Z", "id": "20180321T103711_d020b892-2cf3-11e8-96db-0242ac110003", "fn": "_send_messages", "type": "log", "tb": "'Traceback (most recent call last):\\n  File \"/usr/local/lib/python2.7/dist-packages/deeputil/keep_running.py\", line 150, in _fn\\n    fn(*args, **kwargs)\\n  File \"/usr/local/lib/python2.7/dist-packages/logagg/nsqsender.py\", line 85, in _send_messages\\n    self.session.post(url, data=data, timeout=5) # TODO What if session expires?\\n  File \"/usr/local/lib/python2.7/dist-packages/requests/sessions.py\", line 555, in post\\n    return self.request(\\'POST\\', url, data=data, json=json, **kwargs)\\n  File \"/usr/local/lib/python2.7/dist-packages/requests/sessions.py\", line 508, in request\\n    resp = self.send(prep, **send_kwargs)\\n  File \"/usr/local/lib/python2.7/dist-packages/requests/sessions.py\", line 618, in send\\n    r = adapter.send(request, **kwargs)\\n  File \"/usr/local/lib/python2.7/dist-packages/requests/adapters.py\", line 490, in send\\n    raise ConnectionError(err, request=request)\\nConnectionError: (\\'Connection aborted.\\', error(32, \\'Broken pipe\\'))\\n'", "event": "error_during_run_Continuing", "_": {"ln": 35, "file": "/usr/local/lib/python2.7/dist-packages/logagg/util.py", "name": "logagg.util", "fn": "log_exception"}}
```

